### PR TITLE
Replace caml_js_const by caml_js_expr

### DIFF
--- a/goji_runtime/goji_internal.ml
+++ b/goji_runtime/goji_internal.ml
@@ -50,7 +50,7 @@ let js_global : string -> any = fun n -> js_get (js_symbol "window") n
 
 let js_set_global : string -> any -> unit = fun n v -> js_set (js_symbol "window") n v
 
-external js_constant : string -> any = "caml_js_const"
+external js_constant : string -> any = "caml_js_expr"
 
 external js_call : any -> any array -> any = "caml_js_fun_call"
 


### PR DESCRIPTION
Hello !
Goji is broken with the latest changes in js_of_ocaml, since `caml_js_const` isn't here anymore.
See: https://github.com/ocsigen/js_of_ocaml/commit/36dc6d2593530fcd7a4157743b09b2c722225df3
So I simply replaced it with `caml_js_expr` as suggested by @hhugo on IRC,
